### PR TITLE
Added install recommendation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ PHP 5.5 and later.
 ## Installation
 ### Composer
 
+7.2+ PHP version is required to use Composer.
+
 To install the bindings via [Composer](http://getcomposer.org/), add the following to `composer.json`:
 
 ```javascript
@@ -33,6 +35,8 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
 Then run `composer install`
 
 ### Manual Installation
+
+5.5+ PHP version is required for manual installation.
 
 Download the files and include `autoload.php`:
 


### PR DESCRIPTION
Add under composer:
7.2+ PHP version is required to use Composer.

Add under manual installation: 
5.5+ PHP version is required for manual installation.